### PR TITLE
rdialogs: Refactor command_exists? without `which`

### DIFF
--- a/lib/rdialogs.rb
+++ b/lib/rdialogs.rb
@@ -59,7 +59,9 @@ class RDialogs
   private
 
   def command_exists?(cmd)
-    system("which #{cmd} > /dev/null")
+    ENV['PATH'].split(File::PATH_SEPARATOR).any? do |path|
+      File.executable?(File.join(path, cmd))
+    end
   end
 
   def dialog_size(options)


### PR DESCRIPTION
First of all, thanks for this project -- I've been looking for something like this :smile:.

This PR is pretty simple - it replaces the `system("which")` call in `command_exists?` with a "native" Ruby implementation. This is substantially faster (benchmark below) and more resilient, as `which` is not standardized by POSIX (and is not available at all on Windows).

Here's the benchmark code and results on my machine:

```ruby
require "benchmark"

n = 10_000

def installed_which?(cmd)
  system("which #{cmd} > /dev/null")
end

def installed_native?(cmd)
  ENV["PATH"].split(File::PATH_SEPARATOR).any? do |path|
    File.executable?(File.join(path, cmd))
  end
end

Benchmark.bm do |b|
  b.report "util" do
    n.times { installed_which? "ls" }
  end

  b.report "native" do
    n.times { installed_native? "ls" }
  end
end
```

```bash
$ ruby bench_which.rb 
       user     system      total        real
util  0.360000   0.700000   1.060000 ( 21.150734)
native  0.240000   0.070000   0.310000 (  0.307572)
```

Summary: Running `which` 10000 times takes over 21 seconds, while the "native" equivalent only takes about 300 milliseconds.